### PR TITLE
#2 Use the macros included in serenity's StandardPlatform

### DIFF
--- a/zola/src/commands/color.rs
+++ b/zola/src/commands/color.rs
@@ -7,8 +7,9 @@ use serenity::model::{
 };
 use serenity::utils::Colour;
 use serenity::framework::standard::{
-  macros::command,
+  macros::{command, group},
   CommandResult,
+  CommandError,
   Args,
 };
 use log::{info, error};
@@ -46,38 +47,29 @@ fn hex_to_rgb(hex: &String) -> Result<u64, u64> {
   Ok((r << 16) + (g << 8) + b)
 }
 
+#[group]
+#[prefixes("color", "cl")]
+#[description = "Manage the color of your Discord username."]
+#[default_command(info)]
+#[commands(add, list, delete, set, info)]
+struct Color;
+
 
 #[command]
-fn color(ctx: &mut Context, msg: &Message, mut args: Args) -> CommandResult {
-
-  match args.single::<String>() {
-    Ok(subcommand) => match subcommand.as_ref() {
-      "add" => add_color(ctx, &msg, args),
-      "list" => list_colors(ctx, &msg),
-      "ls" => list_colors(ctx, &msg),
-      "delete" => delete_color(ctx, &msg, args),
-      "rm" => delete_color(ctx, &msg, args),
-      "set" => set_color(ctx, &msg, args),
-      "=" => set_color(ctx, &msg, args),
-      _ => {let _ = msg.channel_id.say(&ctx.http, "The color command accepts the following subcommands: add, list, delete and set");}
-    },
-    Err(_) => {let _ = msg.channel_id.say(&ctx.http, "The color command accepts the following subcommands: add, list, delete and set");},
-  }
+#[description = "Information on the color group"]
+#[help_available(false)]
+fn info(ctx: &mut Context, msg: &Message) -> CommandResult {
+  let _ = msg.channel_id.say(&ctx.http, "**Color Command Usage:**\n\nList available colors with `!color list`\nSet your color with `!color = label`\nCreate a new color with `!color add label #hexcode`\nDelete a color with `!color delete label`");
 
   Ok(())
 }
 
-fn get_starting_color_role_position(roles: &HashMap<RoleId, Role>) -> Result<i64, u8> {
-  for (_, role) in roles {
-    if role.name == "--colors-start-here--" {
-      return Ok(role.position);
-    }
-  }
 
-  Err(0)
-}
-
-fn add_color(ctx: &mut Context, msg: &Message, mut args: Args) {
+#[command]
+#[allowed_roles("Emperor", "Guru")]
+#[description = "Create a new color."]
+#[aliases("create")]
+fn add(ctx: &mut Context, msg: &Message, mut args: Args) -> CommandResult {
   // TODO: Check if calling user is Guru or above
 
   let send_usage_message = || {let _ = msg.channel_id.say(&ctx.http, "Usage: !color add label hexcode");};
@@ -86,44 +78,50 @@ fn add_color(ctx: &mut Context, msg: &Message, mut args: Args) {
 
   let label = if let Ok(label) = args.single_quoted::<String>() { label } else {
     send_usage_message();
-    return;
+    return Ok(());
   };
 
   if label.len() as u32 > COLOR_ROLE_NAME_MAX_WIDTH {
     let _ = msg.channel_id.say(&ctx.http, format!("Error. Reduce label to {} letters or less.", COLOR_ROLE_NAME_MAX_WIDTH));
-    return;
+    return Ok(());
   }
 
   let hexcode = if let Ok(hexcode) = args.single_quoted::<String>() { hexcode } else {
     send_usage_message();
-    return;
+    return Ok(());
   };
 
   if hexcode.len() != 7 || !hexcode.starts_with("#") {
     send_invalid_hexcode_message();
-    return;
+    return Ok(());
   };
 
   if hexcode == "#000000" {
     let _ = msg.channel_id.say(&ctx.http, format!("Discord treats #000000 as \"no color\". I suggest #000001."));
-    return;
+    return Ok(());
   }
 
   let rgb = if let Ok(rgb) = hex_to_rgb(&hexcode) { rgb } else {
     send_invalid_hexcode_message();
-    return;
+    return Ok(());
   };
 
   let guild = if let Some(guild) = msg.guild(&ctx) { guild } else {
     send_something_went_wrong_message();
-    return;
+    return Err(CommandError("Failed to grab guild from msg.guild().".to_string()));
   };
   let guild = guild.read();
 
+  let colors = get_colors(&guild.roles);
+  if colors.contains_key(&label) {
+    let _ = msg.channel_id.say(&ctx.http, format!("That color label is already taken! Try another one."));
+    return Ok(());
+  }
+  
   let color_role_position = if let Ok(position) = get_starting_color_role_position(&guild.roles) { position } else {
     send_something_went_wrong_message();
     devlog(&ctx.http, format!("ERROR: Could not find starting position for color roles. Maybe missing color role marker?"));
-    return;
+    return Err(CommandError("Could not find starting position for color roles. Maybe missing color role marker?".to_string()));
   };
 
   let role_name = String::from("cl:") + &label;
@@ -139,20 +137,26 @@ fn add_color(ctx: &mut Context, msg: &Message, mut args: Args) {
       let _ = msg.channel_id.say(&ctx.http, format!("Could not create that role at this time. Please note this is a failure on nivix's part, not mine."));
     },
   }
+
+  Ok(())
 }
 
-fn list_colors(ctx: &mut Context, msg: &Message) {
+#[command]
+#[bucket = "taxing"]
+#[description = "Preview all available colors."]
+#[aliases("ls", "preview")]
+fn list(ctx: &mut Context, msg: &Message) -> CommandResult {
   let send_something_went_wrong_message = || {let _ = msg.channel_id.say(&ctx.http, "I could not perform the task. Making a note for future improvement.");};
 
   let guild = if let Some(guild) = msg.guild(&ctx) { guild } else {
     send_something_went_wrong_message();
-    return;
+    return Err(CommandError("Failed to grab guild from msg.guild().".to_string()))
   };
 
   let colors = get_colors(&guild.read().roles);
   if colors.len() == 0 {
     let _ = msg.channel_id.say(&ctx.http, "I couldn't find any color roles. Message a Guru for help.");
-    return;
+    return Ok(())
   }
 
   match generate_preview_of_color_roles(colors) {
@@ -167,27 +171,33 @@ fn list_colors(ctx: &mut Context, msg: &Message) {
       devlog(&ctx.http, format!("ERROR: Failed to generate image: {}", why));
     }
   }
+
+  Ok(())
 }
 
-fn delete_color(ctx: &mut Context, msg: &Message, mut args: Args) {
+#[command]
+#[allowed_roles("Emperor", "Guru")]
+#[description = "Delete a color."]
+#[aliases("rm", "remove")]
+fn delete(ctx: &mut Context, msg: &Message, mut args: Args) -> CommandResult {
   let send_usage_message = || {let _ = msg.channel_id.say(&ctx.http, "Usage: !color delete label");};
   let send_something_went_wrong_message = || {let _ = msg.channel_id.say(&ctx.http, "I could not perform the task. Making a note for future improvement.");};
 
   let color_label = if let Ok(color_label) = args.single_quoted::<String>() { color_label } else {
     send_usage_message();
-    return;
+    return Ok(());
   };
 
   let locked_guild = if let Some(guild) = msg.guild(&ctx) { guild } else {
     send_something_went_wrong_message();
-    return;
+    return Err(CommandError("Failed to grab guild from msg.guild().".to_string()))
   };
   let guild = locked_guild.read();
 
   let role_name = String::from("cl:") + &color_label;
   let role = if let Some(role) = guild.role_by_name(&role_name) { role } else {
     let _ = msg.channel_id.say(&ctx.http, format!("There is no role with the name {}. You must be mistaken.", &color_label));
-    return;
+    return Ok(());
   };
 
   match guild.delete_role(&ctx.http, role.id) {
@@ -201,48 +211,52 @@ fn delete_color(ctx: &mut Context, msg: &Message, mut args: Args) {
       devlog(&ctx.http, format!("ERROR: The color role {:?} could not be deleted for this reason {:?}", role, why));
     }
   }
-
+  
+  Ok(())
 }
 
-fn set_color(ctx: &mut Context, msg: &Message, mut args: Args) {
+#[command]
+#[description = "Pick a color."]
+#[aliases("=")]
+fn set(ctx: &mut Context, msg: &Message, mut args: Args) -> CommandResult {
   let send_usage_message = || {let _ = msg.channel_id.say(&ctx.http, "Usage: !color set label");};
   let send_something_went_wrong_message = || {let _ = msg.channel_id.say(&ctx.http, "I could not perform the task. Making a note for future improvement.");};
 
   let label = if let Ok(label) = args.single_quoted::<String>() { label } else {
     send_usage_message();
-    return;
+    return Ok(());
   };
 
   let guild_id = if let Some(guild_id) = msg.guild_id { guild_id } else {
     send_something_went_wrong_message();
-    return;
+    return Err(CommandError("Failed to grab guild_id from msg.guild_id.".to_string()))
   };
 
   let partial_guild = if let Ok(partial_guild) = guild_id.to_partial_guild(&ctx.http) { partial_guild } else {
     send_something_went_wrong_message();
-    return;
+    return Err(CommandError("Failed to convert guild_id to PartialGuild.".to_string()))
   };
 
   let role_name = String::from("cl:") + &label;
   let role = if let Some(role) = partial_guild.role_by_name(&role_name) { role } else {
     let _ = msg.channel_id.say(&ctx.http, format!("No color role exists for label {}.", &label));
-    return;
+    return Ok(());
   };
 
   let mut member = if let Some(member) = msg.member(&ctx) { member } else {
     send_something_went_wrong_message();
-    return;
+    return Err(CommandError("Failed to grab member from msg.member().".to_string()))
   };
 
   let member_roles = if let Some(member_roles) = member.roles(&ctx) { member_roles } else {
     send_something_went_wrong_message();
-    return;
+    return Err(CommandError("Failed to grab roles from member.roles().".to_string()))
   };
 
   for member_role in member_roles {
     if &member_role == role {
       let _ = msg.channel_id.say(&ctx.http, format!("Color {} is already assigned to you.\nIf the color change hasn't taken effect, try typing in a different channel.", &label));
-      return;
+      return Ok(());
     } else if member_role.name.starts_with("cl:") {
       &member.remove_role(&ctx.http, &member_role);
       let _ = msg.channel_id.say(&ctx.http, format!("Removed current color {}.", &member_role.name));
@@ -261,6 +275,17 @@ fn set_color(ctx: &mut Context, msg: &Message, mut args: Args) {
     },
   }
 
+  Ok(())
+}
+
+fn get_starting_color_role_position(roles: &HashMap<RoleId, Role>) -> Result<i64, u8> {
+  for (_, role) in roles {
+    if role.name == "--colors-start-here--" {
+      return Ok(role.position);
+    }
+  }
+
+  Err(0)
 }
 
 fn get_colors(roles: &std::collections::HashMap<serenity::model::id::RoleId, serenity::model::guild::Role>) -> HashMap<String, Colour> {

--- a/zola/src/main.rs
+++ b/zola/src/main.rs
@@ -8,11 +8,16 @@ use std::{
 };
 use serenity::{
     client::bridge::gateway::ShardManager,
-    framework::{
-        StandardFramework,
-        standard::macros::group,
+    framework::standard::{
+      Args,
+      HelpOptions,
+      CommandGroup,
+      CommandResult,
+      help_commands,
+      StandardFramework,
+      macros::help,
     },
-    model::{event::ResumedEvent, gateway::Ready},
+    model::{prelude::*, event::ResumedEvent, gateway::Ready},
     prelude::*,
 };
 use log::{error, info};
@@ -41,49 +46,68 @@ impl EventHandler for Handler {
     }
 }
 
-#[group]
-#[commands(color)]
-struct General;
-
+#[help]
+#[individual_command_tip = "Greetings. If you require more information about a specific command, use !help command."]
+#[max_levenshtein_distance(3)]
+#[indention_prefix = "."]
+#[lacking_permissions = "Hide"]
+#[wrong_channel = "Strike"]
+fn my_help(
+  context: &mut Context,
+  msg: &Message,
+  args: Args,
+  help_options: &'static HelpOptions,
+  groups: &[&'static CommandGroup],
+  owners: HashSet<UserId>
+) -> CommandResult {
+  help_commands::with_embeds(context, msg, args, help_options, groups, owners)
+}
 
 fn main() {
-    // This will load the environment variables located at `./.env`, relative to
-    // the CWD. See `./.env.example` for an example on how to structure this.
-    kankyo::load().expect("Failed to load .env file");
+  // This will load the environment variables located at `./.env`, relative to
+  // the CWD. See `./.env.example` for an example on how to structure this.
+  kankyo::load().expect("Failed to load .env file");
 
-    // Initialize the logger to use environment variables.
-    //
-    // In this case, a good default is setting the environment variable
-    // `RUST_LOG` to debug`.
-    env_logger::init();
+  // Initialize the logger to use environment variables.
+  //
+  // In this case, a good default is setting the environment variable
+  // `RUST_LOG` to debug`.
+  env_logger::init();
 
-    let token = env::var("DISCORD_TOKEN")
-        .expect("Expected a token in the environment");
+  let token = env::var("DISCORD_TOKEN")
+    .expect("Expected a token in the environment");
 
-    let mut client = Client::new(&token, Handler).expect("Err creating client");
+  let mut client = Client::new(&token, Handler).expect("Err creating client");
 
-    {
-        let mut data = client.data.write();
-        data.insert::<ShardManagerContainer>(Arc::clone(&client.shard_manager));
-    }
+  {
+    let mut data = client.data.write();
+    data.insert::<ShardManagerContainer>(Arc::clone(&client.shard_manager));
+  }
 
-    let owners = match client.cache_and_http.http.get_current_application_info() {
-        Ok(info) => {
-            let mut set = HashSet::new();
-            set.insert(info.owner.id);
+  let (owners, bot_id) = match client.cache_and_http.http.get_current_application_info() {
+    Ok(info) => {
+        let mut owners = HashSet::new();
+        owners.insert(info.owner.id);
 
-            set
-        },
-        Err(why) => panic!("Couldn't get application info: {:?}", why),
-    };
+        (owners, info.id)
+    },
+    Err(why) => panic!("Could not access application info: {:?}", why),
+  };
 
-    client.with_framework(StandardFramework::new()
-        .configure(|c| c
-            .owners(owners)
-            .prefix("!"))
-        .group(&GENERAL_GROUP));
+  client.with_framework(StandardFramework::new()
+    .configure(|c| c
+      .on_mention(Some(bot_id))
+      .owners(owners)
+      .prefix("!"))
+    .unrecognised_command(|ctx: &mut Context, msg: &Message, unknown_command_name| {
+      let _ = msg.channel_id.say(&ctx.http, format!("Nivix has not taught me how to help with '{}'. Blame him.", unknown_command_name));
+    })
+    .help(&MY_HELP)
+    .bucket("taxing", |b| b.delay(5))
+    .group(&COLOR_GROUP));
+    
 
-    if let Err(why) = client.start() {
-        error!("Client error: {:?}", why);
-    }
+  if let Err(why) = client.start() {
+    error!("Client error: {:?}", why);
+  }
 }


### PR DESCRIPTION
Moved from my custom command hierarchy to serenity's macro hierarchy.

Also included an additional subcommand for printing usage of all commands when a user types `!color`. This is sub-optimal, but I don't know how to solve it myself yet.