### PR TITLE
Hotfix/#10 ignore commands and bots

### DIFF
--- a/zola/src/main.rs
+++ b/zola/src/main.rs
@@ -43,10 +43,19 @@ impl EventHandler for Handler {
   }
   
   fn message(&self, ctx: Context, message: Message) {
+    // Ignore messages from bots
+    if message.author.bot {
+      return;
+    }
 
     // Make a copy of the message and send it to lowercase, for easier matching
     let mut content = message.content.clone();
     content.make_ascii_lowercase();
+
+    // Ignore command messages
+    if content.starts_with("!") {
+      return;
+    }
 
     // Handle heresy
     if content.contains("heresy") {

--- a/zola/src/main.rs
+++ b/zola/src/main.rs
@@ -5,9 +5,7 @@ use std::{
   collections::HashSet,
   env,
   sync::Arc,
-  path::Path,
-  io,
-  fs::{self, DirEntry},
+  fs,
 };
 use serenity::{
   client::bridge::gateway::ShardManager,


### PR DESCRIPTION
Prevent Zola from passively parsing the following message types:

* Commands (messages starting with !)
* Bot messages